### PR TITLE
Fix/change CaptureRequest implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.settings/
 /.buildpath
 /.project
+*.cache

--- a/composer.json
+++ b/composer.json
@@ -24,15 +24,26 @@
             "email": "hg@superbrave.nl"
         }
     ],
-    "autoload": {
-        "psr-4": { "Omnipay\\DocdataPayments\\" : "src/" }
-    },
     "require": {
         "php": "^7.0",
         "ext-soap": "*",
         "league/omnipay": "^3.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "^8.5",
         "superbrave/coding-standards": "^0.2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Omnipay\\DocdataPayments\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Omnipay\\DocdataPayments\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "325457ee3fc335ba9f97c48cf1b838ec",
+    "content-hash": "c0973230a8840b16b37288f41eda9d30",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -1012,6 +1012,1376 @@
     ],
     "packages-dev": [
         {
+            "name": "doctrine/instantiator",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2019-10-21T16:45:58+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.9.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2020-01-17T21:11:47+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^2.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2018-07-08T19:23:20+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2018-08-07T13:53:10+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "^7.1",
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpdocumentor/type-resolver": "^1.0",
+                "webmozart/assert": "^1"
+            },
+            "require-dev": {
+                "doctrine/instantiator": "^1",
+                "mockery/mockery": "^1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2020-02-22T12:28:44+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/7462d5f123dfc080dfdf26897032a6513644fc95",
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "^7.2",
+                "mockery/mockery": "~1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2020-02-18T18:59:58+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.10.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.5 || ^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2020-03-05T15:02:03+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "7.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f1884187926fbb755a9aaf0b3836ad3165b478bf",
+                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.1.1",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2.2"
+            },
+            "suggest": {
+                "ext-xdebug": "^2.7.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2019-11-20T13:55:58+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2018-09-13T20:33:42+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21T13:50:34+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2019-06-07T04:22:29+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2019-09-17T06:23:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "8.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "018b6ac3c8ab20916db85fa91bf6465acb64d1e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/018b6ac3c8ab20916db85fa91bf6465acb64d1e0",
+                "reference": "018b6ac3c8ab20916db85fa91bf6465acb64d1e0",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.2.0",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.9.1",
+                "phar-io/manifest": "^1.0.3",
+                "phar-io/version": "^2.0.1",
+                "php": "^7.2",
+                "phpspec/prophecy": "^1.8.1",
+                "phpunit/php-code-coverage": "^7.0.7",
+                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.2",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/exporter": "^3.1.1",
+                "sebastian/global-state": "^3.0.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
+                "sebastian/version": "^2.0.1"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
+            "suggest": {
+                "ext-soap": "*",
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^2.0.0"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.5-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2020-01-08T08:49:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2018-07-12T15:12:46+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "time": "2019-02-04T06:01:07+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "4.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2019-11-20T08:46:58+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2019-09-14T09:02:43+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2019-02-01T05:30:01+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-08-03T12:35:26+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2017-03-03T06:23:57+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2018-10-04T04:07:39+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "time": "2019-07-02T08:10:15+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.3.2",
             "source": {
@@ -1094,6 +2464,152 @@
                 "phpcs"
             ],
             "time": "2018-05-09T12:57:33+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
+                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.14-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2020-01-13T11:15:53+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2019-06-13T22:48:21+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "vimeo/psalm": "<3.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2020-02-14T12:15:55+00:00"
         }
     ],
     "aliases": [],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<phpunit
+        backupGlobals='false'
+        backupStaticAttributes='false'
+        colors='true'
+        convertErrorsToExceptions='true'
+        convertNoticesToExceptions='true'
+        convertWarningsToExceptions='true'
+        processIsolation='false'
+        stopOnFailure='false'>
+
+    <testsuites>
+        <testsuite name='omnipay-docdata-payments'>
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -69,7 +69,11 @@ class CaptureRequest extends SoapAbstractRequest
     }
 
     /**
-     * Check all payments to see if we have an authorized one
+     * Returns the first payment available for capturing. When all payments are captured, the last payment is returned.
+     * This will result in an "already captured" error from the payment service provider.
+     *
+     * When no payments are available, null will be returned. This will result in an "invalid payment id" error from
+     * the payment service provider.
      *
      * @param stdClass[] $payments
      *

--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -53,7 +53,9 @@ class CaptureRequest extends SoapAbstractRequest
 
         unset($data['paymentOrderKey']);
 
-        return $soapClient->__soapCall('capture', [$data]);
+        $captureResponse = $soapClient->__soapCall('capture', [$data]);
+
+        return $this->mergeResponses($statusResponse, $captureResponse);
     }
 
     /**
@@ -108,5 +110,25 @@ class CaptureRequest extends SoapAbstractRequest
     private function isPaymentCaptured(stdClass $payment): bool
     {
         return isset($payment->authorization->capture);
+    }
+
+    /**
+     * Returns an stdClass with the multiple responses.
+     *
+     * @param stdClass ...$responses
+     *
+     * @return stdClass
+     */
+    private function mergeResponses(stdClass ...$responses): stdClass
+    {
+        $mergedResponse = new stdClass();
+        foreach ($responses as $response) {
+            $properties = get_object_vars($response);
+            foreach ($properties as $propertyKey => $propertyValue) {
+                $mergedResponse->{$propertyKey} = $propertyValue;
+            }
+        }
+
+        return $mergedResponse;
     }
 }

--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -10,6 +10,19 @@ use Omnipay\Common\Exception\InvalidRequestException;
 class CaptureRequest extends SoapAbstractRequest
 {
     /**
+     * {@inheritdoc}
+     */
+    public function getData()
+    {
+        $this->validate('transactionReference');
+
+        $data = parent::getData();
+        $data['paymentOrderKey'] = $this->getTransactionReference();
+
+        return $data;
+    }
+
+    /**
      * Run the SOAP transaction
      *
      * @param \SoapClient $soapClient Configured SoapClient
@@ -22,9 +35,7 @@ class CaptureRequest extends SoapAbstractRequest
      */
     protected function runTransaction(\SoapClient $soapClient, array $data): \stdClass
     {
-        $statusData = $data;
-        $statusData['paymentOrderKey'] = $this->getTransactionReference();
-        $status = $soapClient->__soapCall('status', [$statusData]);
+        $status = $soapClient->__soapCall('status', [$data]);
 
         $payments = $status->statusSuccess->report->payment;
 

--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -122,7 +122,11 @@ class CaptureRequestTest extends TestCase
         $response = $this->request->send();
 
         $this->assertTrue($response->isSuccessful());
-        $this->assertEquals($this->createCaptureSuccessResponse(), $response->getData());
+
+        $expectedData = $this->createCaptureSuccessResponse();
+        $expectedData->statusSuccess = $this->createStatusSuccessResponse()->statusSuccess;
+
+        $this->assertEquals($expectedData, $response->getData());
     }
 
     /**
@@ -171,7 +175,11 @@ class CaptureRequestTest extends TestCase
         $response = $this->request->send();
 
         $this->assertTrue($response->isSuccessful());
-        $this->assertEquals($this->createCaptureSuccessResponse(), $response->getData());
+
+        $expectedData = $this->createCaptureSuccessResponse();
+        $expectedData->statusSuccess = $this->createStatusSuccessResponseWithMultiplePayments()->statusSuccess;
+
+        $this->assertEquals($expectedData, $response->getData());
     }
 
     /**
@@ -220,7 +228,11 @@ class CaptureRequestTest extends TestCase
         $response = $this->request->send();
 
         $this->assertFalse($response->isSuccessful());
-        $this->assertEquals($this->createCapturePaymentIdIncorrectErrorResponse(), $response->getData());
+
+        $expectedData = $this->createCapturePaymentIdIncorrectErrorResponse();
+        $expectedData->statusErrors = $this->createStatusErrorResponse()->statusErrors;
+
+        $this->assertEquals($expectedData, $response->getData());
     }
 
     /**
@@ -270,7 +282,11 @@ class CaptureRequestTest extends TestCase
         $response = $this->request->send();
 
         $this->assertFalse($response->isSuccessful());
-        $this->assertEquals($this->createCapturePaymentIdIncorrectErrorResponse(), $response->getData());
+
+        $expectedData = $this->createCapturePaymentIdIncorrectErrorResponse();
+        $expectedData->statusSuccess = $this->createStatusSuccessResponse()->statusSuccess;
+
+        $this->assertEquals($expectedData, $response->getData());
     }
 
     /**
@@ -319,7 +335,11 @@ class CaptureRequestTest extends TestCase
         $response = $this->request->send();
 
         $this->assertFalse($response->isSuccessful());
-        $this->assertEquals($this->createCaptureAlreadyCapturedErrorResponse(), $response->getData());
+
+        $expectedData = $this->createCaptureAlreadyCapturedErrorResponse();
+        $expectedData->statusSuccess = $this->createStatusSuccessResponseWithAlreadyCapturedPayment()->statusSuccess;
+
+        $this->assertEquals($expectedData, $response->getData());
     }
 
     /**

--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -22,7 +22,7 @@ class CaptureRequestTest extends TestCase
     private $request;
 
     /**
-     * @var MockObject
+     * @var MockObject|SoapClient
      */
     private $soapClientMock;
 

--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -122,6 +122,7 @@ class CaptureRequestTest extends TestCase
         $response = $this->request->send();
 
         $this->assertTrue($response->isSuccessful());
+        $this->assertEquals($this->createCaptureSuccessResponse(), $response->getData());
     }
 
     /**
@@ -170,6 +171,7 @@ class CaptureRequestTest extends TestCase
         $response = $this->request->send();
 
         $this->assertTrue($response->isSuccessful());
+        $this->assertEquals($this->createCaptureSuccessResponse(), $response->getData());
     }
 
     /**
@@ -218,6 +220,7 @@ class CaptureRequestTest extends TestCase
         $response = $this->request->send();
 
         $this->assertFalse($response->isSuccessful());
+        $this->assertEquals($this->createCapturePaymentIdIncorrectErrorResponse(), $response->getData());
     }
 
     /**
@@ -267,6 +270,7 @@ class CaptureRequestTest extends TestCase
         $response = $this->request->send();
 
         $this->assertFalse($response->isSuccessful());
+        $this->assertEquals($this->createCapturePaymentIdIncorrectErrorResponse(), $response->getData());
     }
 
     /**
@@ -315,6 +319,7 @@ class CaptureRequestTest extends TestCase
         $response = $this->request->send();
 
         $this->assertFalse($response->isSuccessful());
+        $this->assertEquals($this->createCaptureAlreadyCapturedErrorResponse(), $response->getData());
     }
 
     /**

--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -1,0 +1,492 @@
+<?php
+
+namespace Omnipay\DocdataPayments\Tests\Message;
+
+use Omnipay\Common\Exception\InvalidRequestException;
+use Omnipay\Common\Http\ClientInterface;
+use Omnipay\DocdataPayments\Message\CaptureRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use SoapClient;
+use stdClass;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Tests for {@see CaptureRequest}.
+ */
+class CaptureRequestTest extends TestCase
+{
+    /**
+     * @var CaptureRequest
+     */
+    private $request;
+
+    /**
+     * @var MockObject
+     */
+    private $soapClientMock;
+
+    /**
+     * Creates a new {@see CaptureRequest} and related mocks for testing.
+     */
+    protected function setUp(): void
+    {
+        $httpClientMock = $this->getMockBuilder(ClientInterface::class)
+            ->getMock();
+
+        $this->soapClientMock = $this->getMockBuilder(SoapClient::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->request = new CaptureRequest($httpClientMock, Request::create('/'), $this->soapClientMock);
+        $this->request->setMerchantName('superbrave_nl');
+        $this->request->setMerchantPassword('12345');
+        $this->request->setTransactionReference('79A783DEFG6D38F1C74B4B4AECC8F2E1');
+    }
+
+    /**
+     * Tests if {@see CaptureRequest::send} throws an {@see InvalidRequestException} when
+     * the transaction reference is not set.
+     */
+    public function testSendThrowsInvalidRequestExceptionWhenTransactionReferenceNotAvailable(): void
+    {
+        $this->request->setTransactionReference(null);
+
+        $this->expectException(InvalidRequestException::class);
+        $this->expectExceptionMessage('The transactionReference parameter is required');
+
+        $this->request->send();
+    }
+
+    /**
+     * Tests if {@see CaptureRequest::send} returns a successful {@see CaptureResponse} when it successfully
+     * sends a capture request for a payment.
+     *
+     * @depends testSendThrowsInvalidRequestExceptionWhenTransactionReferenceNotAvailable
+     */
+    public function testSendSuccessfulCapture(): void
+    {
+        $this->soapClientMock->expects($this->exactly(2))
+            ->method('__soapCall')
+            ->withConsecutive(
+                [
+                    'status',
+                    $this->callback(function ($data) {
+                        unset($data[0]['integrationInfo']);
+
+                        $this->assertSame(
+                            [
+                                [
+                                    'version' => '1.3',
+                                    'merchant' => [
+                                        'name' => 'superbrave_nl',
+                                        'password' => '12345',
+                                    ],
+                                    'paymentOrderKey' => '79A783DEFG6D38F1C74B4B4AECC8F2E1',
+                                ],
+                            ],
+                            $data
+                        );
+
+                        return true;
+                    }),
+                ],
+                [
+                    'capture',
+                    $this->callback(function ($data) {
+                        unset($data[0]['integrationInfo']);
+
+                        $this->assertSame(
+                            [
+                                [
+                                    'version' => '1.3',
+                                    'merchant' => [
+                                        'name' => 'superbrave_nl',
+                                        'password' => '12345',
+                                    ],
+                                    'paymentId' => 3058909231,
+                                ],
+                            ],
+                            $data
+                        );
+
+                        return true;
+                    }),
+                ]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->createStatusSuccessResponse(),
+                $this->createCaptureSuccessResponse()
+            );
+
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+    }
+
+    /**
+     * Tests if {@see CaptureRequest::send} returns a successful {@see CaptureResponse} when it successfully
+     * sends a capture request one of multiple payments.
+     *
+     * @depends testSendSuccessfulCapture
+     */
+    public function testSendSuccessfulCaptureWithMultiplePaymentsOnOrder(): void
+    {
+        $this->soapClientMock->expects($this->exactly(2))
+            ->method('__soapCall')
+            ->withConsecutive(
+                [
+                    'status',
+                    $this->isType('array'),
+                ],
+                [
+                    'capture',
+                    $this->callback(function ($data) {
+                        unset($data[0]['integrationInfo']);
+
+                        $this->assertSame(
+                            [
+                                [
+                                    'version' => '1.3',
+                                    'merchant' => [
+                                        'name' => 'superbrave_nl',
+                                        'password' => '12345',
+                                    ],
+                                    'paymentId' => 3058909232,
+                                ],
+                            ],
+                            $data
+                        );
+
+                        return true;
+                    }),
+                ]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->createStatusSuccessResponseWithMultiplePayments(),
+                $this->createCaptureSuccessResponse()
+            );
+
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+    }
+
+    /**
+     * Tests if {@see CaptureRequest::send} returns an unsuccessful {@see CaptureResponse} when
+     * the internal status request fails.
+     *
+     * @depends testSendSuccessfulCapture
+     */
+    public function testSendNotSuccessfulCaptureWhenStatusRequestFails(): void
+    {
+        $this->soapClientMock->expects($this->exactly(2))
+            ->method('__soapCall')
+            ->withConsecutive(
+                [
+                    'status',
+                    $this->isType('array'),
+                ],
+                [
+                    'capture',
+                    $this->callback(function ($data) {
+                        unset($data[0]['integrationInfo']);
+
+                        $this->assertSame(
+                            [
+                                [
+                                    'version' => '1.3',
+                                    'merchant' => [
+                                        'name' => 'superbrave_nl',
+                                        'password' => '12345',
+                                    ],
+                                    'paymentId' => 0,
+                                ],
+                            ],
+                            $data
+                        );
+
+                        return true;
+                    }),
+                ]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->createStatusErrorResponse(),
+                $this->createCapturePaymentIdIncorrectErrorResponse()
+            );
+
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+    }
+
+    /**
+     * Tests if {@see CaptureRequest::send} returns an unsuccessful {@see CaptureResponse} when trying to capture
+     * an already captured payment.
+     *
+     * @depends testSendSuccessfulCapture
+     */
+    public function testSendNotSuccessfulCaptureWhenPaymentIdIncorrect(): void
+    {
+        $this->markTestIncomplete();
+        $this->soapClientMock->expects($this->exactly(2))
+            ->method('__soapCall')
+            ->withConsecutive(
+                [
+                    'status',
+                    $this->isType('array'),
+                ],
+                [
+                    'capture',
+                    $this->callback(function ($data) {
+                        unset($data[0]['integrationInfo']);
+
+                        $this->assertSame(
+                            [
+                                [
+                                    'version' => '1.3',
+                                    'merchant' => [
+                                        'name' => 'superbrave_nl',
+                                        'password' => '12345',
+                                    ],
+                                    'paymentId' => 3058909231,
+                                ],
+                            ],
+                            $data
+                        );
+
+                        return true;
+                    }),
+                ]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->createStatusSuccessResponse(),
+                $this->createCapturePaymentIdIncorrectErrorResponse()
+            );
+
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+    }
+
+    /**
+     * Tests if {@see CaptureRequest::send} returns an unsuccessful {@see CaptureResponse} when trying to capture
+     * an already captured payment.
+     *
+     * @depends testSendSuccessfulCapture
+     */
+    public function testSendNotSuccessfulCaptureWhenAlreadyCaptured(): void
+    {
+        $this->soapClientMock->expects($this->exactly(2))
+            ->method('__soapCall')
+            ->withConsecutive(
+                [
+                    'status',
+                    $this->isType('array'),
+                ],
+                [
+                    'capture',
+                    $this->callback(function ($data) {
+                        unset($data[0]['integrationInfo']);
+
+                        $this->assertSame(
+                            [
+                                [
+                                    'version' => '1.3',
+                                    'merchant' => [
+                                        'name' => 'superbrave_nl',
+                                        'password' => '12345',
+                                    ],
+                                    'paymentId' => 3058909231,
+                                ],
+                            ],
+                            $data
+                        );
+
+                        return true;
+                    }),
+                ]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->createStatusSuccessResponseWithAlreadyCapturedPayment(),
+                $this->createCaptureAlreadyCapturedErrorResponse()
+            );
+
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+    }
+
+    /**
+     * Returns a new stdClass representing a successful status SOAP call.
+     *
+     * @return stdClass
+     */
+    private function createStatusSuccessResponse(): stdClass
+    {
+        $response = new stdClass();
+        $response->statusSuccess = new stdClass();
+        $response->statusSuccess->_ = 'Operation successful.';
+        $response->statusSuccess->code = 'SUCCESS';
+        $response->statusSuccess->report = new stdClass();
+        $response->statusSuccess->report->approximateTotals = new stdClass();
+        $response->statusSuccess->report->approximateTotals->totalRegistered = 1000;
+        $response->statusSuccess->report->approximateTotals->totalShopperPending = 0;
+        $response->statusSuccess->report->approximateTotals->totalAcquirerPending = 0;
+        $response->statusSuccess->report->approximateTotals->totalAcquirerApproved = 1000;
+        $response->statusSuccess->report->approximateTotals->totalCaptured = 0;
+        $response->statusSuccess->report->approximateTotals->totalRefunded = 0;
+        $response->statusSuccess->report->approximateTotals->totalChargedback = 0;
+        $response->statusSuccess->report->approximateTotals->totalReversed = 0;
+        $response->statusSuccess->report->approximateTotals->exchangedTo = 'EUR';
+        $response->statusSuccess->report->approximateTotals->exchangeRateDate = '2020-03-10 10:58:16';
+        $response->statusSuccess->report->payment = new stdClass();
+        $response->statusSuccess->report->payment->id = 3058909231;
+        $response->statusSuccess->report->payment->paymentMethod = 'ELV';
+        $response->statusSuccess->report->payment->authorization = new stdClass();
+        $response->statusSuccess->report->payment->authorization->status = 'AUTHORIZED';
+        $response->statusSuccess->report->payment->authorization->amount = new stdClass();
+        $response->statusSuccess->report->payment->authorization->amount->_ = 1000;
+        $response->statusSuccess->report->payment->authorization->amount->currency = 'EUR';
+        $response->statusSuccess->report->payment->authorization->amount->confidenceLevel = 'ACQUIRER_APPROVED';
+        $response->statusSuccess->report->consideredSafe = new stdClass();
+        $response->statusSuccess->report->consideredSafe->value = true;
+        $response->statusSuccess->report->consideredSafe->level = 'SAFE';
+        $response->statusSuccess->report->consideredSafe->date = '2020-03-06T12:05:50.846+01:00';
+        $response->statusSuccess->report->consideredSafe->reason = 'EXACT_MATCH';
+        $response->statusSuccess->report->apiInformation = new stdClass();
+        $response->statusSuccess->report->apiInformation->originalVersion = '1.3';
+        $response->statusSuccess->report->apiInformation->conversionApplied = false;
+        $response->statusSuccess->ddpXsdVersion = '1.3.14';
+
+        return $response;
+    }
+
+    /**
+     * Returns a new stdClass representing a successful status SOAP call with multiple payments.
+     *
+     * @return stdClass
+     */
+    private function createStatusSuccessResponseWithMultiplePayments(): stdClass
+    {
+        $response = $this->createStatusSuccessResponse();
+
+        $response->statusSuccess->report->approximateTotals->totalRegistered = 2000;
+        $response->statusSuccess->report->approximateTotals->totalAcquirerApproved = 1000;
+        $response->statusSuccess->report->approximateTotals->totalCaptured = 1000;
+
+        $firstPayment = new stdClass();
+        $firstPayment->id = 3058909231;
+        $firstPayment->paymentMethod = 'ELV';
+        $firstPayment->authorization = new stdClass();
+        $firstPayment->authorization->status = 'AUTHORIZED';
+        $firstPayment->authorization->amount = new stdClass();
+        $firstPayment->authorization->amount->_ = 1000;
+        $firstPayment->authorization->amount->currency = 'EUR';
+        $firstPayment->authorization->amount->confidenceLevel = 'ACQUIRER_APPROVED';
+        $firstPayment->authorization->capture = new stdClass();
+        $firstPayment->authorization->capture->status = 'CAPTURED';
+        $firstPayment->authorization->capture->amount = new stdClass();
+        $firstPayment->authorization->capture->amount->_ = 1000;
+        $firstPayment->authorization->capture->amount->currency = 'EUR';
+
+        $secondPayment = new stdClass();
+        $secondPayment->id = 3058909232;
+        $secondPayment->paymentMethod = 'ELV';
+        $secondPayment->authorization = new stdClass();
+        $secondPayment->authorization->status = 'AUTHORIZED';
+        $secondPayment->authorization->amount = new stdClass();
+        $secondPayment->authorization->amount->_ = 1000;
+        $secondPayment->authorization->amount->currency = 'EUR';
+        $secondPayment->authorization->amount->confidenceLevel = 'ACQUIRER_APPROVED';
+
+        $response->statusSuccess->report->payment = [$firstPayment, $secondPayment];
+
+        return $response;
+    }
+
+    /**
+     * Returns a new stdClass representing a successful status SOAP call with an already captured payment.
+     *
+     * @return stdClass
+     */
+    private function createStatusSuccessResponseWithAlreadyCapturedPayment(): stdClass
+    {
+        $response = $this->createStatusSuccessResponse();
+
+        $response->statusSuccess->report->approximateTotals->totalAcquirerApproved = 1000;
+        $response->statusSuccess->report->approximateTotals->totalCaptured = 1000;
+
+        $response->statusSuccess->report->payment->authorization->capture = new stdClass();
+        $response->statusSuccess->report->payment->authorization->capture->status = 'CAPTURED';
+        $response->statusSuccess->report->payment->authorization->capture->amount = new stdClass();
+        $response->statusSuccess->report->payment->authorization->capture->amount->_ = 1000;
+        $response->statusSuccess->report->payment->authorization->capture->amount->currency = 'EUR';
+
+        return $response;
+    }
+
+    /**
+     * Returns a new stdClass representing an unsuccessful status SOAP call.
+     *
+     * @return stdClass
+     */
+    private function createStatusErrorResponse(): stdClass
+    {
+        $response = new stdClass();
+        $response->statusErrors = new stdClass();
+        $response->statusErrors->error = new stdClass();
+        $response->statusErrors->error->_ = 'Order could not be found with the given key.';
+        $response->statusErrors->error->code = 'REQUEST_DATA_INCORRECT';
+
+        return $response;
+    }
+
+    /**
+     * Returns a new stdClass representing a successful capture SOAP call.
+     *
+     * @return stdClass
+     */
+    private function createCaptureSuccessResponse(): stdClass
+    {
+        $response = new stdClass();
+        $response->captureSuccess = new stdClass();
+        $response->captureSuccess->success = new stdClass();
+        $response->captureSuccess->success->_ = 'Operation successful.';
+        $response->captureSuccess->success->code = 'SUCCESS';
+
+        return $response;
+    }
+
+    /**
+     * Returns a new stdClass representing an unsuccessful capture SOAP call when the provided payment id is incorrect.
+     *
+     * @return stdClass
+     */
+    private function createCapturePaymentIdIncorrectErrorResponse(): stdClass
+    {
+        $response = new stdClass();
+        $response->captureErrors = new stdClass();
+        $response->captureErrors->error = new stdClass();
+        $response->captureErrors->error->_ = 'Payment id incorrect.';
+        $response->captureErrors->error->code = 'REQUEST_DATA_INCORRECT';
+
+        return $response;
+    }
+
+    /**
+     * Returns a new stdClass representing an unsuccessful capture SOAP call when the payment is already captured.
+     *
+     * @return stdClass
+     */
+    private function createCaptureAlreadyCapturedErrorResponse(): stdClass
+    {
+        $response = new stdClass();
+        $response->captureErrors = new stdClass();
+        $response->captureErrors->error = new stdClass();
+        $response->captureErrors->error->_ = 'No amount authorized available to capture.';
+        $response->captureErrors->error->code = 'REQUEST_DATA_INCORRECT';
+
+        return $response;
+    }
+}


### PR DESCRIPTION
This PR adds tests for the various `CaptureRequest` scenarios and fixes PHP errors within the current implementation.

Please note that this also changes a capture on an already captured payment to not successful. Also a capture SOAP call is now always made to CM Payments (previously known as DocData Payments).