### PR TITLE
Change an unsuccessful capture to successful when all payments are already captured

### DIFF
--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -237,13 +237,12 @@ class CaptureRequestTest extends TestCase
 
     /**
      * Tests if {@see CaptureRequest::send} returns an unsuccessful {@see CaptureResponse} when trying to capture
-     * an already captured payment.
+     * an incorrect payment ID.
      *
      * @depends testSendSuccessfulCapture
      */
     public function testSendNotSuccessfulCaptureWhenPaymentIdIncorrect(): void
     {
-        $this->markTestIncomplete();
         $this->soapClientMock->expects($this->exactly(2))
             ->method('__soapCall')
             ->withConsecutive(

--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -289,12 +289,12 @@ class CaptureRequestTest extends TestCase
     }
 
     /**
-     * Tests if {@see CaptureRequest::send} returns an unsuccessful {@see CaptureResponse} when trying to capture
+     * Tests if {@see CaptureRequest::send} returns a successful {@see CaptureResponse} when trying to capture
      * an already captured payment.
      *
      * @depends testSendSuccessfulCapture
      */
-    public function testSendNotSuccessfulCaptureWhenAlreadyCaptured(): void
+    public function testSendSuccessfulCaptureWhenAlreadyCaptured(): void
     {
         $this->soapClientMock->expects($this->exactly(2))
             ->method('__soapCall')
@@ -333,9 +333,14 @@ class CaptureRequestTest extends TestCase
 
         $response = $this->request->send();
 
-        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame('No amount authorized available to capture.', $response->getMessage());
 
         $expectedData = $this->createCaptureAlreadyCapturedErrorResponse();
+        $expectedData->captureSuccess = new stdClass();
+        $expectedData->captureSuccess->success = new stdClass();
+        $expectedData->captureSuccess->success->code = 'SUCCESS';
+        $expectedData->captureSuccess->success->_ = 'No amount authorized available to capture.';
         $expectedData->statusSuccess = $this->createStatusSuccessResponseWithAlreadyCapturedPayment()->statusSuccess;
 
         $this->assertEquals($expectedData, $response->getData());


### PR DESCRIPTION
This PR changes an unsuccessful capture back to successful when all payments are already captured. 

This is required/handy to facilitate the same workflow for both directly captured payment methods (like iDeal) and delayed captured payment methods (like ELV).